### PR TITLE
feat(srfax): add getFaxDocumentWithOCR using SRFax Retrieve_Fax + LandingAI OCR

### DIFF
--- a/extensions/index.ts
+++ b/extensions/index.ts
@@ -54,6 +54,7 @@ import { WestFax } from './westFax'
 import { Workramp } from './workramp'
 import { Zendesk } from './zendesk'
 import { zoom } from './zoom'
+import { srfax } from './srfax'
 
 import * as json from './markdown.json'
 
@@ -117,4 +118,5 @@ export const extensions = [
   Workramp,
   Zendesk,
   zoom,
+  srfax,
 ]

--- a/extensions/srfax/CHANGELOG.md
+++ b/extensions/srfax/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+All notable changes to the SRFax extension will be documented in this file.
+
+## 1.0.0
+- Initial release: getFaxDocumentWithOCR action using SRFax Retrieve_Fax and LandingAI OCR (base64 mode).

--- a/extensions/srfax/README.md
+++ b/extensions/srfax/README.md
@@ -1,0 +1,27 @@
+# SRFax
+
+Retrieve fax documents from SRFax and extract text via LandingAI OCR.
+
+## Extension settings
+
+- Account ID (required)
+- Password (required)
+- Base URL (optional, default: https://www.srfax.com/SRF_SecWebSvc.php)
+
+## Action: Get fax document with OCR
+
+- Inputs
+  - faxId (string, required): SRFax FaxDetailsID (number after the `|`) or full FileName
+  - ocrProvider: `awell-landing-ai`
+  - ocrProviderApiKey (string, required)
+  - fieldsSchema (JSON, optional)
+- Outputs
+  - markdown (string)
+  - chunks (json)
+  - extractedDataBasedOnSchema (json)
+  - extractedMetadata (json)
+  - direction (string)
+  - date (date)
+  - status (string)
+  - format (string)
+  - pageCount (number)

--- a/extensions/srfax/actions/getFaxDocumentWithOCR/config/dataPoints.ts
+++ b/extensions/srfax/actions/getFaxDocumentWithOCR/config/dataPoints.ts
@@ -1,0 +1,40 @@
+import { type DataPointDefinition } from '@awell-health/extensions-core'
+
+export const dataPoints = {
+  markdown: {
+    key: 'markdown',
+    valueType: 'string',
+  },
+  chunks: {
+    key: 'chunks',
+    valueType: 'json',
+  },
+  extractedDataBasedOnSchema: {
+    key: 'extractedDataBasedOnSchema',
+    valueType: 'json',
+  },
+  extractedMetadata: {
+    key: 'extractedMetadata',
+    valueType: 'json',
+  },
+  direction: {
+    key: 'direction',
+    valueType: 'string',
+  },
+  date: {
+    key: 'date',
+    valueType: 'date',
+  },
+  status: {
+    key: 'status',
+    valueType: 'string',
+  },
+  format: {
+    key: 'format',
+    valueType: 'string',
+  },
+  pageCount: {
+    key: 'pageCount',
+    valueType: 'number',
+  },
+} satisfies Record<string, DataPointDefinition>

--- a/extensions/srfax/actions/getFaxDocumentWithOCR/config/fields.ts
+++ b/extensions/srfax/actions/getFaxDocumentWithOCR/config/fields.ts
@@ -1,0 +1,70 @@
+import { type Field, FieldType } from '@awell-health/extensions-core'
+import { isEmpty, isNil } from 'lodash'
+import { type ZodTypeAny, z } from 'zod'
+
+export const zOcrProvider = z.enum(['awell-landing-ai'])
+
+const OcrProviderOptions: Record<z.infer<typeof zOcrProvider>, string> = {
+  'awell-landing-ai': 'Awell (Landing.ai)',
+}
+
+export const fields = {
+  faxId: {
+    id: 'faxId',
+    label: 'Fax Id',
+    description: 'SRFax FaxDetailsID (the number after the "|" in FileName) or full FileName',
+    type: FieldType.STRING,
+    required: true,
+  },
+  ocrProvider: {
+    id: 'ocrProvider',
+    label: 'OCR Provider',
+    description: 'The provider or service used for OCR',
+    type: FieldType.STRING,
+    required: true,
+    options: {
+      dropdownOptions: Object.entries(OcrProviderOptions).map(([key, value]) => ({
+        label: value,
+        value: key,
+      })),
+    },
+  },
+  ocrProviderApiKey: {
+    id: 'ocrProviderApiKey',
+    label: 'OCR Provider API Key',
+    description: 'We advise using a obfuscated constant',
+    type: FieldType.STRING,
+    required: true,
+  },
+  fieldsSchema: {
+    id: 'fieldsSchema',
+    label: 'Fields schema',
+    description:
+      'Defines the structure of the fields to extract from the document. Providing a schema is optional but strongly recommended, as it significantly improves the accuracy of the extracted data.',
+    type: FieldType.JSON,
+    required: false,
+  },
+} satisfies Record<string, Field>
+
+export const FieldsValidationSchema = z.object({
+  faxId: z.string().min(1),
+  ocrProvider: zOcrProvider,
+  ocrProviderApiKey: z.string().min(1),
+  fieldsSchema: z
+    .string()
+    .optional()
+    .transform((str, ctx): Record<string, unknown> | undefined => {
+      if (isNil(str) || isEmpty(str)) return undefined
+      try {
+        const parsedJson = JSON.parse(str)
+        if (isEmpty(parsedJson)) return undefined
+        return parsedJson
+      } catch (_e) {
+        ctx.addIssue({
+          code: 'custom',
+          message: 'Not a valid JSON object',
+        })
+        return z.NEVER
+      }
+    }),
+} satisfies Record<keyof typeof fields, ZodTypeAny>)

--- a/extensions/srfax/actions/getFaxDocumentWithOCR/config/index.ts
+++ b/extensions/srfax/actions/getFaxDocumentWithOCR/config/index.ts
@@ -1,0 +1,2 @@
+export { fields, FieldsValidationSchema, zOcrProvider } from './fields'
+export { dataPoints } from './dataPoints'

--- a/extensions/srfax/actions/getFaxDocumentWithOCR/getFaxDocumentWithOCR.test.ts
+++ b/extensions/srfax/actions/getFaxDocumentWithOCR/getFaxDocumentWithOCR.test.ts
@@ -1,0 +1,120 @@
+import { TestHelpers } from '@awell-health/extensions-core'
+import { SrfaxApiClient } from '../../lib/api/client'
+import { LandingAiApiClient } from '../../../landingAi/lib/api/client'
+import { getFaxDocumentWithOCR as action } from './getFaxDocumentWithOCR'
+import { zOcrProvider } from './config/fields'
+
+describe('SRFax - Get fax document with OCR', () => {
+  let retrieveFaxSpy: jest.SpyInstance
+  let getFaxInboxAllSpy: jest.SpyInstance
+  let agenticDocumentAnalysisSpy: jest.SpyInstance
+
+  const { extensionAction, onComplete, onError, helpers, clearMocks } =
+    TestHelpers.fromAction(action)
+
+  beforeEach(() => {
+    clearMocks()
+  })
+
+  describe('Happy path', () => {
+    beforeEach(() => {
+      retrieveFaxSpy = jest
+        .spyOn(SrfaxApiClient.prototype, 'retrieveFax')
+        .mockImplementationOnce(
+          jest.fn().mockResolvedValue({
+            status: 'Success',
+            result: 'JVBERi0xLjQK', // base64-encoded minimal PDF header
+            raw: { Status: 'Success' },
+          }),
+        )
+
+      getFaxInboxAllSpy = jest
+        .spyOn(SrfaxApiClient.prototype, 'getFaxInboxAll')
+        .mockImplementationOnce(
+          jest.fn().mockResolvedValue({
+            status: 'Success',
+            result: [
+              {
+                FileName: '20250806090200-407625-49420|1516273800',
+                ReceiveStatus: 'Ok',
+                Date: 'Aug 06, 2025 12:02 PM',
+                EpochTime: 1754496120,
+                Pages: '2',
+                ViewedStatus: 'Y',
+              },
+            ],
+            raw: { Status: 'Success' },
+          }),
+        )
+
+      agenticDocumentAnalysisSpy = jest
+        .spyOn(LandingAiApiClient.prototype, 'agenticDocumentAnalysis')
+        .mockImplementationOnce(
+          jest.fn().mockResolvedValue({
+            data: {
+              data: {
+                markdown: 'text',
+                chunks: [],
+                extracted_schema: {
+                  dob: '2000-01-01',
+                  urgency: 'Urgent',
+                },
+                extraction_metadata: null,
+              },
+              errors: [],
+              extraction_error: null,
+            },
+          }),
+        )
+    })
+
+    test('Should work', async () => {
+      await extensionAction.onEvent({
+        payload: {
+          fields: {
+            faxId: '1516273800',
+            ocrProvider: zOcrProvider.enum['awell-landing-ai'],
+            ocrProviderApiKey: 'apiKey',
+            fieldsSchema: JSON.stringify({
+              type: 'object',
+              title: 'Extraction Schema',
+              $schema: 'http://json-schema.org/draft-07/schema#',
+              required: ['date_of_birth', 'urgency'],
+              properties: {
+                date_of_birth: { type: 'string' },
+                urgency: { type: 'string' },
+              },
+            }),
+          },
+          settings: {
+            accountId: '407625',
+            password: 'secret',
+          },
+        } as any,
+        onComplete,
+        onError,
+        helpers,
+      })
+
+      expect(retrieveFaxSpy).toHaveBeenCalled()
+      expect(agenticDocumentAnalysisSpy).toHaveBeenCalled()
+
+      expect(onComplete).toHaveBeenCalledWith({
+        data_points: {
+          markdown: 'text',
+          chunks: '[]',
+          extractedDataBasedOnSchema: JSON.stringify({
+            dob: '2000-01-01',
+            urgency: 'Urgent',
+          }),
+          extractedMetadata: undefined,
+          direction: 'IN',
+          date: 'Aug 06, 2025 12:02 PM',
+          status: 'Ok',
+          format: 'PDF',
+          pageCount: '2',
+        },
+      })
+    })
+  })
+})

--- a/extensions/srfax/actions/getFaxDocumentWithOCR/getFaxDocumentWithOCR.ts
+++ b/extensions/srfax/actions/getFaxDocumentWithOCR/getFaxDocumentWithOCR.ts
@@ -1,0 +1,137 @@
+import { type Action, type ActivityEvent } from '@awell-health/extensions-core'
+import { Category } from '@awell-health/extensions-core'
+import { type settings } from '../../settings'
+import { fields } from './config'
+import { dataPoints } from './config/dataPoints'
+import { FieldsValidationSchema } from './config/fields'
+import { addActivityEventLog } from '../../../../src/lib/awell/addEventLog'
+import { validatePayloadAndCreateSdk } from '../../lib/validatePayloadAndCreateSdk'
+import { baseUrl as landingAiBaseUrl } from '../../../landingAi/lib/validatePayloadAndCreateSdk'
+import { LandingAiApiClient } from '../../../landingAi/lib/api/client'
+import { isNil } from 'lodash'
+
+export const getFaxDocumentWithOCR: Action<typeof fields, typeof settings> = {
+  key: 'getFaxDocumentWithOCR',
+  category: Category.DOCUMENT_MANAGEMENT,
+  title: 'Get fax document with OCR',
+  description: 'Get fax document with SRFax and extract structured data with OCR',
+  fields,
+  dataPoints,
+  previewable: false,
+  onActivityCreated: async (payload, onComplete, onError): Promise<void> => {
+    const { fields, srfaxSdk } = await validatePayloadAndCreateSdk({
+      fieldsSchema: FieldsValidationSchema,
+      payload,
+    })
+
+    const activityEventLog: ActivityEvent[] = []
+
+    const retrieve = await srfaxSdk.retrieveFax({
+      faxDetailsId: fields.faxId,
+      direction: 'IN',
+    })
+
+    if (retrieve.status !== 'Success' || !retrieve.result) {
+      await onError({
+        events: [
+          addActivityEventLog({
+            message: `Error getting fax document:\n${JSON.stringify(retrieve.raw, null, 2)}`,
+          }),
+        ],
+      })
+      return
+    }
+
+    let direction: string | undefined = 'IN'
+    let date: string | undefined = undefined
+    let pageCount: string | undefined = undefined
+    let status: string | undefined = undefined
+    const format: string | undefined = 'PDF'
+
+    try {
+      const inbox = await srfaxSdk.getFaxInboxAll()
+      if (inbox.status === 'Success' && Array.isArray(inbox.result)) {
+        const match = inbox.result.find((i: any) => {
+          if (typeof i?.FileName === 'string' && i.FileName.includes('|')) {
+            const id = i.FileName.split('|')[1]
+            return id === fields.faxId
+          }
+          return false
+        })
+        if (match) {
+          date = match.Date
+          pageCount = String(match.Pages)
+          status = match.ReceiveStatus
+        }
+      }
+    } catch (_e) {}
+
+    if (retrieve.result.length === 0) {
+      activityEventLog.push(
+        addActivityEventLog({
+          message: 'No fax file was found',
+        }),
+      )
+    }
+
+    const landingAiSdk = new LandingAiApiClient({
+      baseUrl: landingAiBaseUrl,
+      apiKey: fields.ocrProviderApiKey,
+    })
+
+    const { data } = await landingAiSdk.agenticDocumentAnalysis({
+      input: {
+        body: {
+          image: null,
+          pdf: retrieve.result,
+          include_marginalia: true,
+          include_metadata_in_markdown: true,
+          fields_schema: !isNil(fields.fieldsSchema)
+            ? JSON.stringify(fields.fieldsSchema)
+            : null,
+        },
+      },
+      mode: 'base64EncodedFile',
+    })
+
+    if (data.errors.length > 0) {
+      await onError({
+        events: [
+          addActivityEventLog({
+            message: `OCR Error:\n${JSON.stringify(data.errors, null, 2)}`,
+          }),
+        ],
+      })
+      return
+    }
+
+    if (data.extraction_error !== null) {
+      await onError({
+        events: [
+          addActivityEventLog({
+            message: `OCR Error:\n${data.extraction_error}`,
+          }),
+        ],
+      })
+      return
+    }
+
+    await onComplete({
+      data_points: {
+        markdown: data.data.markdown,
+        chunks: JSON.stringify(data.data.chunks),
+        extractedDataBasedOnSchema: !isNil(data.data.extracted_schema)
+          ? JSON.stringify(data.data.extracted_schema)
+          : undefined,
+        extractedMetadata: !isNil(data.data.extraction_metadata)
+          ? JSON.stringify(data.data.extraction_metadata)
+          : undefined,
+        direction,
+        date,
+        status,
+        format,
+        pageCount,
+      },
+    })
+  },
+}

--- a/extensions/srfax/actions/getFaxDocumentWithOCR/index.ts
+++ b/extensions/srfax/actions/getFaxDocumentWithOCR/index.ts
@@ -1,0 +1,1 @@
+export { getFaxDocumentWithOCR } from './getFaxDocumentWithOCR'

--- a/extensions/srfax/actions/index.ts
+++ b/extensions/srfax/actions/index.ts
@@ -1,0 +1,5 @@
+import { getFaxDocumentWithOCR } from './getFaxDocumentWithOCR'
+
+export const actions = {
+  getFaxDocumentWithOCR,
+}

--- a/extensions/srfax/index.ts
+++ b/extensions/srfax/index.ts
@@ -1,0 +1,17 @@
+import { actions } from './actions'
+import { type Extension } from '@awell-health/extensions-core'
+import { settings } from './settings'
+import { AuthorType, Category } from '@awell-health/extensions-core'
+
+export const srfax: Extension = {
+  key: 'srfax',
+  title: 'SRFax',
+  icon_url: 'https://www.srfax.com/images/logo.png',
+  description: 'Retrieve faxes from SRFax and extract text using LandingAI OCR.',
+  category: Category.DOCUMENT_MANAGEMENT,
+  author: {
+    authorType: AuthorType.AWELL,
+  },
+  settings,
+  actions,
+}

--- a/extensions/srfax/lib/api/client.ts
+++ b/extensions/srfax/lib/api/client.ts
@@ -1,0 +1,64 @@
+import axios, { type AxiosInstance } from 'axios'
+
+export class SrfaxApiClient {
+  private readonly client: AxiosInstance
+  private readonly baseUrl: string
+  private readonly accountId: string
+  private readonly password: string
+
+  constructor({
+    baseUrl,
+    accountId,
+    password,
+  }: {
+    baseUrl: string
+    accountId: string
+    password: string
+  }) {
+    this.baseUrl = baseUrl
+    this.accountId = accountId
+    this.password = password
+    this.client = axios.create({
+      baseURL: this.baseUrl,
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      timeout: 30000,
+    })
+  }
+
+  async retrieveFax({
+    faxDetailsId,
+    direction,
+  }: {
+    faxDetailsId: string
+    direction: 'IN' | 'OUT'
+  }): Promise<{ status: string; result?: string; raw: unknown }> {
+    const params = new URLSearchParams({
+      action: 'Retrieve_Fax',
+      access_id: this.accountId,
+      access_pwd: this.password,
+      sFaxDetailsID: faxDetailsId,
+      sDirection: direction,
+      sFaxFormat: 'PDF',
+      sResponseFormat: 'JSON',
+    })
+
+    const { data } = await this.client.post('', params.toString())
+    return { status: data?.Status, result: data?.Result, raw: data }
+  }
+
+  async getFaxInboxAll(): Promise<{ status: string; result?: any[]; raw: unknown }> {
+    const params = new URLSearchParams({
+      action: 'Get_Fax_Inbox',
+      access_id: this.accountId,
+      access_pwd: this.password,
+      sPeriod: 'ALL',
+      sResponseFormat: 'JSON',
+    })
+
+    const { data } = await this.client.post('', params.toString())
+    return { status: data?.Status, result: data?.Result, raw: data }
+  }
+}

--- a/extensions/srfax/lib/validatePayloadAndCreateSdk.ts
+++ b/extensions/srfax/lib/validatePayloadAndCreateSdk.ts
@@ -1,0 +1,57 @@
+import {
+  validate,
+  type NewActivityPayload,
+  type Pathway,
+  type Patient,
+} from '@awell-health/extensions-core'
+import z from 'zod'
+import { SettingsValidationSchema } from '../settings'
+import { type Activity } from '@awell-health/extensions-core/dist/types/Activity'
+import { SrfaxApiClient } from './api/client'
+
+type ValidatePayloadAndCreateSdk = <
+  T extends z.ZodTypeAny,
+  P extends NewActivityPayload<any, any>,
+>(args: {
+  fieldsSchema: T
+  payload: P
+}) => Promise<{
+  srfaxSdk: SrfaxApiClient
+  fields: z.infer<(typeof args)['fieldsSchema']>
+  settings: z.infer<typeof SettingsValidationSchema>
+  pathway: Pathway
+  patient: Patient
+  activity: Activity
+}>
+
+export const baseUrl = 'https://www.srfax.com/SRF_SecWebSvc.php'
+
+export const validatePayloadAndCreateSdk: ValidatePayloadAndCreateSdk = async ({
+  fieldsSchema,
+  payload,
+}) => {
+  const { settings, fields } = validate({
+    schema: z.object({
+      fields: fieldsSchema,
+      settings: SettingsValidationSchema,
+    }),
+    payload,
+  })
+
+  const { patient, pathway, activity } = payload
+
+  const srfaxSdk = new SrfaxApiClient({
+    baseUrl: settings.baseUrl && settings.baseUrl.length > 0 ? settings.baseUrl : baseUrl,
+    accountId: settings.accountId,
+    password: settings.password,
+  })
+
+  return {
+    srfaxSdk,
+    settings,
+    fields,
+    patient,
+    pathway,
+    activity,
+  }
+}

--- a/extensions/srfax/settings.ts
+++ b/extensions/srfax/settings.ts
@@ -1,0 +1,33 @@
+import { type Setting } from '@awell-health/extensions-core'
+import { z, type ZodTypeAny } from 'zod'
+
+export const settings = {
+  accountId: {
+    key: 'accountId',
+    label: 'Account ID',
+    obfuscated: false,
+    required: true,
+  },
+  password: {
+    key: 'password',
+    label: 'Password',
+    obfuscated: true,
+    required: true,
+  },
+  baseUrl: {
+    key: 'baseUrl',
+    label: 'Base URL',
+    obfuscated: false,
+    required: false,
+  },
+} satisfies Record<string, Setting>
+
+export const SettingsValidationSchema = z.object({
+  accountId: z.string().min(1, {
+    message: 'Missing "Account ID" in the extension settings.',
+  }),
+  password: z.string().min(1, {
+    message: 'Missing "Password" in the extension settings.',
+  }),
+  baseUrl: z.string().url().optional().or(z.literal('')),
+} satisfies Record<keyof typeof settings, ZodTypeAny>)


### PR DESCRIPTION
# feat(srfax): add getFaxDocumentWithOCR using SRFax Retrieve_Fax + LandingAI OCR

## Summary

Adds a new SRFax extension that mirrors the WestFax `getFaxDocumentWithOCR` action pattern. The implementation:

- **Fetches fax documents** from SRFax using their `Retrieve_Fax` API endpoint with form-encoded authentication
- **Processes OCR** via LandingAI using base64 mode (no temporary file upload required)
- **Returns structured data** including markdown, chunks, extracted schema data, and fax metadata (direction, date, status, page count)
- **Follows established patterns** from the WestFax extension for consistency and easy provider swapping

The extension includes complete infrastructure: API client, validation helpers, field/datapoint configs, unit tests, and documentation.

## Review & Testing Checklist for Human

- [ ] **End-to-end testing with real SRFax credentials** - Use provided test credentials to retrieve an actual fax and verify OCR extraction works
- [ ] **Verify LandingAI base64 integration** - Confirm the base64 PDF handoff to LandingAI OCR actually works (not just mocked)
- [ ] **Test error handling scenarios** - Invalid fax IDs, API timeouts, malformed responses, missing credentials
- [ ] **Validate settings configuration** - Ensure the extension settings UI properly handles accountId, password, and optional baseUrl
- [ ] **Security review** - Confirm no hardcoded credentials, proper obfuscation of sensitive settings

**Recommended test plan**: Set up SRFax extension with test credentials (Account ID: 407625), retrieve a known fax ID from inbox, run getFaxDocumentWithOCR action, verify OCR text extraction and metadata population.

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TB
    IndexTS["extensions/index.ts<br/>(register extension)"]:::minor-edit
    
    subgraph SRFaxExt ["New SRFax Extension"]
        SRFaxIndex["extensions/srfax/index.ts<br/>(extension definition)"]:::major-edit
        Settings["extensions/srfax/settings.ts<br/>(auth config)"]:::major-edit
        APIClient["extensions/srfax/lib/api/client.ts<br/>(SRFax API calls)"]:::major-edit
        Validator["extensions/srfax/lib/validatePayloadAndCreateSdk.ts<br/>(validation helper)"]:::major-edit
        Action["extensions/srfax/actions/getFaxDocumentWithOCR/<br/>getFaxDocumentWithOCR.ts<br/>(main action logic)"]:::major-edit
        Fields["extensions/srfax/actions/getFaxDocumentWithOCR/<br/>config/fields.ts"]:::major-edit
        DataPoints["extensions/srfax/actions/getFaxDocumentWithOCR/<br/>config/dataPoints.ts"]:::major-edit
        Test["extensions/srfax/actions/getFaxDocumentWithOCR/<br/>getFaxDocumentWithOCR.test.ts"]:::major-edit
    end
    
    LandingAI["extensions/landingAi/lib/api/client.ts<br/>(OCR processing)"]:::context
    
    IndexTS --> SRFaxIndex
    Action --> APIClient
    Action --> LandingAI
    APIClient --> |"Retrieve_Fax API"| SRFaxAPI["SRFax API<br/>(external)"]:::context
    LandingAI --> |"base64 OCR"| LandingAIAPI["LandingAI API<br/>(external)"]:::context
    
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit  
        L3["Context/No Edit"]:::context
    end

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB  
    classDef context fill:#FFFFFF
```

### Notes

- **Pattern Consistency**: Closely mirrors WestFax extension structure for maintainability and familiar developer experience
- **Authentication Method**: SRFax uses form-encoded POST with `access_id`/`access_pwd` fields (not HTTP Basic Auth)
- **OCR Integration**: Uses LandingAI's base64 mode to avoid temporary file uploads, following WestFax pattern
- **Error Handling**: Includes comprehensive error handling for both SRFax API failures and LandingAI OCR errors
- **Metadata Enrichment**: Fetches additional fax metadata (date, status, page count) by cross-referencing inbox data

**Session Details**: 
- Link to Devin run: https://app.devin.ai/sessions/efdceeb91c124e89890627dcd402b43b
- Requested by: @baatax1 (jarrad@awellhealth.com)