### PR TITLE
chore(srfax): update icon_url to Cloudinary asset

### DIFF
--- a/extensions/srfax/index.ts
+++ b/extensions/srfax/index.ts
@@ -6,7 +6,7 @@ import { AuthorType, Category } from '@awell-health/extensions-core'
 export const srfax: Extension = {
   key: 'srfax',
   title: 'SRFax',
-  icon_url: 'https://www.srfax.com/images/logo.png',
+  icon_url: 'https://res.cloudinary.com/dbhuqasw0/image/upload/v1754994599/1545794_648668791846553_275530089_n-300x300_gq9m32.jpg',
   description: 'Retrieve faxes from SRFax and extract text using LandingAI OCR.',
   category: Category.DOCUMENT_MANAGEMENT,
   author: {


### PR DESCRIPTION
# chore(srfax): update icon_url to Cloudinary asset

## Summary

Updates the SRFax extension icon from the original SRFax website URL to a Cloudinary-hosted asset for UI consistency with other extensions like Availity. This is a simple cosmetic change that improves the visual presentation in the Awell Extensions UI.

## Review & Testing Checklist for Human

- [ ] **Verify icon renders correctly** - Check that the new Cloudinary URL displays the SRFax icon properly in the extensions UI
- [ ] **Confirm no broken links** - Ensure the Cloudinary asset is accessible and won't expire

**Recommended test plan**: Load the extensions UI and verify the SRFax extension shows the correct icon without any broken image indicators.

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TB
    SRFaxIndex["extensions/srfax/index.ts<br/>(icon_url updated)"]:::minor-edit
    
    ExtensionsUI["Extensions UI<br/>(renders icon)"]:::context
    
    OldIcon["SRFax Website<br/>(old icon source)"]:::context
    NewIcon["Cloudinary Asset<br/>(new icon source)"]:::context
    
    SRFaxIndex --> |"displays in"| ExtensionsUI
    SRFaxIndex -.-> |"replaced"| OldIcon
    SRFaxIndex --> |"now uses"| NewIcon
    
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit  
        L3["Context/No Edit"]:::context
    end

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB  
    classDef context fill:#FFFFFF
```

### Notes

- **Low risk change**: This is purely cosmetic - only updates the icon_url property from `https://www.srfax.com/images/logo.png` to the provided Cloudinary URL
- **Consistency improvement**: Aligns with other extensions like Availity that use hosted assets rather than external website URLs
- **No functional impact**: The SRFax extension's core functionality remains unchanged

**Session Details**: 
- Link to Devin run: https://app.devin.ai/sessions/efdceeb91c124e89890627dcd402b43b
- Requested by: @baatax1 (jarrad@awellhealth.com)